### PR TITLE
remove prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-node_modules
-dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-	"endOfLine": "lf",
-	"arrowParens": "always",
-	"useTabs": true,
-	"tabWidth": 4,
-	"semi": true
-}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	],
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"lint": "eslint . --ext .ts && yarn prettier --write .",
+		"lint": "npx eslint . --ext .ts",
+		"lint:fix": "npx eslint . --ext .ts --fix",
 		"start": "npx tsc && npm link && npx create-web3-dapp"
 	},
 	"bin": {
@@ -31,8 +32,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.32.0",
 		"@typescript-eslint/parser": "^5.32.0",
 		"eslint": "^8.21.0",
-		"eslint-config-next": "12.2.3",
-		"prettier": "^2.7.1"
+		"eslint-config-next": "12.2.3"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
This PR:
- fixes inconsistent use of `npx` in scripts, regarding to `lint`
- resolves the conflicts between ESlint and Prettier by removing the latter entirely (please see #46)
- adds `lint:fix` script for autolinting (before that, ESlint' default check was followed by Prettier' autolinting)