### PR TITLE
Add Github actions for linting and testing

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,32 @@
+name: Development
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    check:
+        name: Set up checks
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out Git repository
+              uses: actions/checkout@v2
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16
+
+            - name: Install Node.js dependencies
+              run: npm ci
+
+            - name: Run linters
+              run: npm run lint
+
+            - name: Run tests
+              run: npm run test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"chakra-ui"
 	],
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "echo \"No test specified\" && exit 0",
 		"lint": "eslint . --ext .ts && yarn prettier --write .",
 		"start": "npx tsc && npm link && npx create-web3-dapp"
 	},


### PR DESCRIPTION
Related to #23 and #43.

This PR adds a simple .yml workflow for linting and testing the code prior to merging with main.
The workflow is a Development one, but idk whether we would need Staging/Production CI logic on this project haha.

For now, it works **only** on _main_ commits + on PRs headed towards _main_.
There is no problem in extending these triggers in the future btw.

You can see the example of such Action right in this PR. Don't pay attention to the failing checks, for now this is caused by #46.
But, I guess, after completing this PR, it will be great to prohibit merges on failed CI/CD in project setting.