### PR TITLE
Upgrade `@solana/wallet-adapter-react` for compatibility with Mobile Wallet Adapter and the Wallet Standard

### DIFF
--- a/helpers/utils/generatePackageDotJson.ts
+++ b/helpers/utils/generatePackageDotJson.ts
@@ -38,14 +38,14 @@ export const generatePackageDotJson = (
 	} else {
 		frontEndPackageJson["dependencies"]["@project-serum/borsh"] = "^0.2.5";
 		frontEndPackageJson["dependencies"]["@solana/wallet-adapter-react-ui"] =
-			"^0.9.11";
+			"^0.9.19-rc.4";
 		frontEndPackageJson["dependencies"]["@solana/wallet-adapter-phantom"] =
 			"^0.9.8";
 		frontEndPackageJson["dependencies"]["@solana/wallet-adapter-react"] =
-			"^0.15.8";
+			"^0.15.21-rc.4";
 		frontEndPackageJson["dependencies"]["@solana/wallet-adapter-base"] =
 			"^0.9.9";
-		frontEndPackageJson["dependencies"]["@solana/web3.js"] = "^1.50.1";
+		frontEndPackageJson["dependencies"]["@solana/web3.js"] = "^1.58.0";
 	}
 
 	if (useBackend) {


### PR DESCRIPTION
# Description

In this PR we upgrade `@solana/wallet-adapter-react` to a version that has the following benefits:

1. The ability to connect to _any_ mobile wallet app that supports the Solana Mobile Stack Mobile Wallet Adapter Protocol.
2. The ability to connect to _any_ desktop wallet that supports the Solana Wallet Standard.

You can read much more about the wider effort to upgrade the entire ecosystem of Solana web apps at: https://github.com/solana-labs/wallet-adapter/issues/604

## Test plan

### Mobile, with mobile wallet

https://user-images.githubusercontent.com/13243/197322284-05a7f9f4-fedc-4cb5-8dd7-b9cbd360d19f.mp4

### Desktop, with desktop wallets

https://user-images.githubusercontent.com/13243/197322270-1ac60d9b-0352-480d-a06d-a5ffc11b6b21.mov