### PR TITLE
Add network support for Polygon zkEVM Mainnet and Testnet

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -54,6 +54,7 @@ With create-web3-dapp you can create multi-chain dapps supporting all of the maj
 
 - [x] Ethereum
 - [x] Polygon
+- [x] Polygon zkEVM
 - [x] Arbitrum
 - [x] Optimism
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please refer to this package's documentation and the following links for an in d
 
 create-web3-dapp is an npx tool that allows developers to **create web3 applications in ~4 minutes.**
 
-The dapp created with create-web3-dapp are NextJS-based, and **compatible with the most used blockchains such as Ethereum, Polygon, Optimism, Arbitrum, and Solana**. Create-web3-dapp allows web3 developers to build production-ready decentralized applications at lightning speed, using pre-made React components, webhooks, and APIs.
+The dapp created with create-web3-dapp are NextJS-based, and **compatible with the most used blockchains such as Ethereum, Polygon, Polygon zkEVM, Optimism, Arbitrum, and Solana**. Create-web3-dapp allows web3 developers to build production-ready decentralized applications at lightning speed, using pre-made React components, webhooks, and APIs.
 
 No complicated configuration or folder structures, only the files you need to build your Dapp.
 

--- a/helpers/core/workflows/standardWorkflow.ts
+++ b/helpers/core/workflows/standardWorkflow.ts
@@ -130,6 +130,7 @@ export async function startStandardWorkflow() {
 					choices: [
 						{ title: "Ethereum", value: "ETH_MAINNET" },
 						{ title: "Polygon", value: "MATIC_MAINNET" },
+						{ title: "Polygon zkEVM", value: "POLYGON_ZKEVM_MAINNET" },
 						{ title: "Arbitrum", value: "ARB_MAINNET" },
 						{ title: "Optimism", value: "OPT_MAINNET" },
 						{ title: "Back", value: "back" },

--- a/helpers/core/workflows/templatesWorkflow.ts
+++ b/helpers/core/workflows/templatesWorkflow.ts
@@ -55,6 +55,7 @@ export async function startTemplatesWorkflow(useBackend = false, projectName?) {
 					choices: [
 						{ title: "Ethereum", value: "ETH_MAINNET" },
 						{ title: "Polygon", value: "MATIC_MAINNET" },
+						{ title: "Polygon zkEVM", value: "POLYGON_ZKEVM_MAINNET" },
 						{ title: "Arbitrum", value: "ARB_MAINNET" },
 						{ title: "Optimism", value: "OPT_MAINNET" },
 						{ title: "Back", value: "back" },

--- a/helpers/utils/generateAlchemyUrl.ts
+++ b/helpers/utils/generateAlchemyUrl.ts
@@ -18,6 +18,14 @@ export const generateAlchemyURL = (chain): string => {
 			rpcUrl =
 				"`https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`";
 			break;
+		case "POLYGON_ZKEVM_MAINNET":
+			rpcUrl =
+				"`https://polygonzkevm-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`";
+			break;
+		case "POLYGON_ZKEVM_TESTNET":
+			rpcUrl =
+				"`https://polygonzkevm-testnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`";
+			break;
 		case "ARB_MAINNET":
 			rpcUrl =
 				"`https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`";

--- a/helpers/utils/getDefaultRainbowkitChain.ts
+++ b/helpers/utils/getDefaultRainbowkitChain.ts
@@ -6,6 +6,8 @@ export const getDefaultRainbowkitChain = function (chain: string): string {
 		OPT_MAINNET: "arbitrum",
 		ETH_GOERLI: "goerli",
 		MATIC_MUMBAI: "polygonMumbai",
+		POLYGON_ZKEVM_MAINNET: "polygonZkEvm",
+		POLYGON_ZKEVM_TESTNET: "polygonZkEvmTestnet",
 		ARB_GOERLI: "arbitrumGoerli",
 		OPT_GOERLI: "optimismGoerli",
 	};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"foundry",
 		"ethereum",
 		"polygon",
+		"polygon-zkevm",
 		"solana",
 		"optimism",
 		"arbitrum",


### PR DESCRIPTION
## Changes
This PR adds network support for Polygon zkEVM to Alchemy's create-web3-dapp including
- Polygon zkEVM Mainnet
- Polygon zkEVM Testnet

## Dependencies
It depends on Alchemy rpc url support for Polygon zkEVM and [wagmi support](https://wagmi.sh/core/chains#supported-chains) for the 2 new networks
✅ polygonZkEvm
✅ polygonZkEvmTestnet

## Notes
I didn't have Github permissions to create a polygon-zkevm branch within the main create-web3-dapp repo, so I forked and created a branch with my changes.