### PR TITLE
Fix: updated outro.js with correct start command

### DIFF
--- a/src/utils/outro.js
+++ b/src/utils/outro.js
@@ -51,7 +51,7 @@ export async function printOutroMessage(projectName) {
        yarn deploy
 
     ${chalk.dim("5.")} ${chalk.bold("Start the frontend")} 🌟
-       yarn dev
+       yarn start
 
     ${chalk.bold.green(
 		"Thanks for using Scaffold Alchemy! Let's build something amazing! 🙏 ✨"


### PR DESCRIPTION
According to the `package.json`, the correct startup command is `yarn start`. Simple update in the `outro.js`.

<img width="193" alt="image" src="https://github.com/user-attachments/assets/e8722889-a5eb-40ff-9915-fde4d1309993" />
